### PR TITLE
update (primary) shards expression to (total # of) shards

### DIFF
--- a/files/dashboards/openshift-logging-dashboard.json
+++ b/files/dashboards/openshift-logging-dashboard.json
@@ -249,7 +249,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "max(es_cluster_shards_number{type=\"active_primary\"})",
+              "expr": "max(es_cluster_shards_number{type=\"active\"})",
               "instant": true,
               "refId": "A"
             }


### PR DESCRIPTION
### Description
---
This PR: Updates `es_cluster_shards_number` expr for the Openshift Logging dashboard (not the Logging / Elasticseach one) to showcase accurate value for "total number of" Elasticsearch shards as mentioned in the [documentation](https://docs.openshift.com/container-platform/4.9/logging/cluster-logging-dashboards.html) (_as opposed to the current value of "total primary shards"_).

Here is the version we are using :

~~~
$> oc get csv
NAME                                 DISPLAY                                          VERSION    REPLACES                             PHASE
elasticsearch-operator.5.3.5-20      OpenShift Elasticsearch Operator                 5.3.5-20   elasticsearch-operator.5.3.4-13      Succeeded
~~~

Using the values in an example : (e.g. `max(es_cluster_shards_number{cluster="elasticsearch",type="active"})` value = 13 & `max(es_cluster_shards_number{cluster="elasticsearch",type="active_primary"})` value = 11 )

I could start a fresh cluster from OpenTLC, like the Hands-On OpenShift 4.9 which is available now, and I would have the same behavior.

I would expect to see 13 because the [docs](https://docs.openshift.com/container-platform/4.9/logging/cluster-logging-dashboards.html) state : 

> Elastic Shards | The total number of Elasticsearch shards in the Elasticsearch instance. 

However, the value shown is 11.

/cc @shwetaap
/assign @jcantrill

<br>
<br>

### Links
---
- [x] JIRA: [Dashboard for OpenShift Logging in WebConsole shows incorrect number of shards](https://issues.redhat.com/browse/LOG-2156) <-- linking this JIRA as upon upgrading to the latest instance and I can see this is now using `max` instead of `sum(sum by(instance)` . So this is great, however, still need to adjust `active_primary` to `active` for total shards in the Elasticsearch instance, **not** total _primary_ shards.
- [x] SLACK thread: [#forum-logging](https://coreos.slack.com/archives/CB3HXM2QK/p1648548203813369?thread_ts=1645215311.915799&cid=CB3HXM2QK)

